### PR TITLE
Surplus-Power-Mode

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -272,6 +272,7 @@ struct CONFIG_T {
         uint32_t FullSolarPassThroughSoc;
         float FullSolarPassThroughStartVoltage;
         float FullSolarPassThroughStopVoltage;
+        bool SurplusPowerEnabled;
     } PowerLimiter;
 
     struct {

--- a/include/Statistic.h
+++ b/include/Statistic.h
@@ -1,0 +1,46 @@
+#pragma once
+
+
+template <typename T>
+class WeightedAVG {
+public:
+    WeightedAVG(int16_t factor)
+      : _countMax(factor)
+      , _count(0), _countNum(0), _avgV(0), _minV(0), _maxV(0), _lastV(0)  {}
+
+    void addNumber(const T& num) {
+      if (_count == 0){
+          _count++;
+          _avgV = num;
+          _minV = num;
+          _maxV = num;
+          _countNum = 1;
+      } else {
+          if (_count < _countMax)
+              _count++;
+          _avgV = (_avgV * (_count - 1) + num) / _count;
+          if (num < _minV) _minV = num;
+          if (num > _maxV) _maxV = num;
+          _countNum++;
+      }
+      _lastV = num;
+    }
+
+    void reset(void) { _count = 0; _avgV = 0; _minV = 0; _maxV = 0; _lastV = 0; _countNum = 0; }
+    void reset(const T& num) { _count = 0; addNumber(num); }
+    T getAverage() const { return _avgV; }
+    T getMin() const { return _minV; }
+    T getMax() const { return _maxV; }
+    T getLast() const { return _lastV; }
+    int32_t getCounts() const { return _countNum; }
+
+private:
+    int16_t _countMax;    // weighting factor (10 => 1/10 => 10%)
+    int16_t _count;       // counter (0 - _countMax)
+    int32_t _countNum;    // counts the amount of added numbers
+    T _avgV;               // average value
+    T _minV;               // minimum value
+    T _maxV;               // maximum value
+    T _lastV;              // last value
+};
+

--- a/include/SurplusPower.h
+++ b/include/SurplusPower.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <Arduino.h>
+#include <frozen/string.h>
+#include "Statistic.h"
+
+
+class SurplusPowerClass {
+    public:
+        SurplusPowerClass() = default;
+        ~SurplusPowerClass() = default;
+
+        bool useSurplusPower(void) const;
+        int32_t calcSurplusPower(int32_t const requestedPower);
+
+    private:
+        enum class SurplusState : uint8_t {
+            IDLE = 0,
+            TRY_MORE = 1,
+            REDUCE_POWER = 2,
+            IN_TARGET = 3,
+            MAXIMUM_POWER = 4,
+        };
+
+        enum class Text : uint8_t {
+            Q_NODATA = 0,
+            Q_EXCELLENT = 1,
+            Q_GOOD = 2,
+            Q_BAD = 3,
+            T_HEAD = 4
+        };
+
+        frozen::string const& getStatusText(SurplusPowerClass::SurplusState state);
+        frozen::string const& getText(SurplusPowerClass::Text tNr);
+        void handleQualityCounter(void);
+
+        // to handle regulation
+        SurplusState _surplusState = SurplusState::IDLE;    // actual regulation state
+        float _absorptionVoltage = -1.0f;                   // from MPPT
+        float _floatVoltage = -1.0f;                        // from MPPT
+        int32_t _powerStep = 50;                            // power step size in W (default)
+        int32_t _surplusPower = 0;                          // actual surplus power
+        int32_t _inTargetTime = 0;                          // records the time we hit the target power
+        WeightedAVG<float> _avgMPPTVoltage {3};             // the average helps to smooth the regulation
+
+        // to handle the quality counter
+        int8_t _qualityCounter = 0;                         // quality counter
+        WeightedAVG<float> _qualityAVG {20};                // quality counter average
+        int32_t _lastAddPower = 0;                          // last power step
+};
+
+extern SurplusPowerClass SurplusPower;

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -249,6 +249,7 @@ bool ConfigurationClass::write()
     powerlimiter["full_solar_passthrough_soc"] = config.PowerLimiter.FullSolarPassThroughSoc;
     powerlimiter["full_solar_passthrough_start_voltage"] = config.PowerLimiter.FullSolarPassThroughStartVoltage;
     powerlimiter["full_solar_passthrough_stop_voltage"] = config.PowerLimiter.FullSolarPassThroughStopVoltage;
+    powerlimiter["surplus_power_enabled"] = config.PowerLimiter.SurplusPowerEnabled;
 
     JsonObject battery = doc["battery"].to<JsonObject>();
     battery["enabled"] = config.Battery.Enabled;
@@ -596,6 +597,7 @@ bool ConfigurationClass::read()
     config.PowerLimiter.FullSolarPassThroughSoc = powerlimiter["full_solar_passthrough_soc"] | POWERLIMITER_FULL_SOLAR_PASSTHROUGH_SOC;
     config.PowerLimiter.FullSolarPassThroughStartVoltage = powerlimiter["full_solar_passthrough_start_voltage"] | POWERLIMITER_FULL_SOLAR_PASSTHROUGH_START_VOLTAGE;
     config.PowerLimiter.FullSolarPassThroughStopVoltage = powerlimiter["full_solar_passthrough_stop_voltage"] | POWERLIMITER_FULL_SOLAR_PASSTHROUGH_STOP_VOLTAGE;
+    config.PowerLimiter.SurplusPowerEnabled = powerlimiter["surplus_power_enabled"] | false;
 
     JsonObject battery = doc["battery"];
     config.Battery.Enabled = battery["enabled"] | BATTERY_ENABLED;

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -17,6 +17,7 @@
 #include <ctime>
 #include <cmath>
 #include <frozen/map.h>
+#include "SurplusPower.h"
 
 PowerLimiterClass PowerLimiter;
 
@@ -522,6 +523,10 @@ bool PowerLimiterClass::calcPowerLimit(std::shared_ptr<InverterAbstract> inverte
         MessageOutput.printf("[DPL::calcPowerLimit] match household consumption with limit of %d W\r\n",
             newPowerLimit);
     }
+
+    // use surplus power if active
+    if (SurplusPower.useSurplusPower())
+        newPowerLimit = SurplusPower.calcSurplusPower(newPowerLimit);
 
     // Case 3:
     return setNewPowerLimit(inverter, newPowerLimit);

--- a/src/SurplusPower.cpp
+++ b/src/SurplusPower.cpp
@@ -1,0 +1,253 @@
+/* Surplus-Power-Mode
+ *
+ * The Surplus-Power-Mode regulates the inverter output power based on the surplus solar power.
+ * Surplus solar power is available when the battery is (almost) full and the available
+ * solar power is higher than the power consumed in the household.
+ *
+ * Basic principe:
+ * In absorption- and float-mode the MPPT acts like a constant voltage source with current limiter.
+ * In that modes we do not get any reliable maximum power or maximum current information from the MPPT.
+ * To find the maximum solar power we regulate the inverter power, we go higher and higher, step by step,
+ * until we reach the current limit and the voltage begins to drop. When we go one step back and check if
+ * the voltage is back above the target voltage. A kind of simple approximation control.
+ *
+ * Notes:
+ * We need Victron VE.Direct Rx/Tx (text-mode and hex-mode) to get all necessary data for the regulation
+ *
+ * 2024.08.10 - 1.0 - first version
+ *
+ */
+#include "Configuration.h"
+#include "VictronMppt.h"
+#include "MessageOutput.h"
+#include "SurplusPower.h"
+
+
+// support for debugging, 0 = without extended logging, 1 = with extended logging, 2 = with more extended logging
+constexpr int MODULE_DEBUG = 2;
+
+
+#define DELTA_VOLTAGE 0.05f     // we allow some difference between absorption voltage and target voltage
+#define MAX_STEPS 20            // amount of power steps for the approximation
+#define TIME_OUT 60000          // 60 sec regulation step-up timeout
+#define MODE_ABSORPTION 4       // MPPT in absorption mode
+#define MODE_FLOAT 5            // MPPT in float mode
+#define NOT_VALID -1.0f         // if data is not available for any reason
+
+
+SurplusPowerClass SurplusPower;
+
+
+/*
+ * useSurplusPower()
+ * check if surplus-power-mode is enabled
+ * return:  true = enabled, false = not enabled
+ */
+bool SurplusPowerClass::useSurplusPower(void) const {
+    CONFIG_T const& config = Configuration.get();
+
+    return (config.PowerLimiter.SurplusPowerEnabled) ? true : false;
+}
+
+
+/*
+ * handleQualityCounter()
+ * check if the regulation quality counter can be added to the quality statistic
+ */
+void SurplusPowerClass::handleQualityCounter(void) {
+    if (_qualityCounter != 0)
+        _qualityAVG.addNumber(_qualityCounter);
+    _qualityCounter = 0;
+}
+
+
+/*
+ * calcSurplusPower()
+ * calculates the surplus power if MPPT indicates absorption or float mode
+ * requested power: the power based on actual calculation from "Zero feed throttle" or "Solar-Passthrough"
+ * return:          maximum power ("actual solar power" or "requested power")
+ */
+int32_t SurplusPowerClass::calcSurplusPower(int32_t const requestedPower) {
+
+    // MPPT in absorption or float mode?
+    auto vStOfOp = VictronMppt.getStateOfOperation();
+    if ((vStOfOp != MODE_ABSORPTION) && (vStOfOp != MODE_FLOAT)) {
+        _surplusPower = 0.0;
+        _surplusState = SurplusState::IDLE;
+        return requestedPower;
+    }
+
+    // get the absorption/float voltage from MPPT
+    auto xVoltage = VictronMppt.getVoltage(VictronMpptClass::MPPTVoltage::ABSORPTION);
+    if (xVoltage != NOT_VALID) _absorptionVoltage = xVoltage;
+    xVoltage = VictronMppt.getVoltage(VictronMpptClass::MPPTVoltage::FLOAT);
+    if (xVoltage != NOT_VALID) _floatVoltage = xVoltage;
+    if ((_absorptionVoltage == NOT_VALID) || (_floatVoltage == NOT_VALID)) {
+        MessageOutput.printf("%s Not possible. Absorption/Float voltage from MPPT is not available\r\n",
+        getText(Text::T_HEAD).data());
+        return requestedPower;
+    }
+
+    // get the battery voltage from MPPT
+    // Note: like the MPPT we use the MPPT voltage and not the voltage from the battery for regulation
+    auto mpptVoltage = VictronMppt.getVoltage(VictronMpptClass::MPPTVoltage::BATTERY);
+    if (mpptVoltage == NOT_VALID) {
+        MessageOutput.printf("%s Not possible. Battery voltage from MPPT is not available\r\n",
+        getText(Text::T_HEAD).data());
+        return requestedPower;
+    }
+    _avgMPPTVoltage.addNumber(mpptVoltage);
+    auto avgMPPTVoltage = _avgMPPTVoltage.getAverage();
+
+    // set the regulation target voltage threshold
+    // todo: Check if we need the double DELTA_VOLTAGE on 48V or more power full systems
+    auto targetVoltage = (vStOfOp == MODE_ABSORPTION) ? _absorptionVoltage - DELTA_VOLTAGE: _floatVoltage - DELTA_VOLTAGE;
+
+    // state machine: hold, increase or decrease the surplus power
+    CONFIG_T& config = Configuration.get();
+    int32_t addPower = 0;
+    switch (_surplusState) {
+
+        case SurplusState::IDLE:
+            // start check if all necessary information is available
+            _powerStep = config.PowerLimiter.UpperPowerLimit / MAX_STEPS;
+            _surplusPower = requestedPower;
+            _surplusState = SurplusState::TRY_MORE;
+            _qualityCounter = 0;
+            _qualityAVG.reset();
+            break;
+
+        case SurplusState::TRY_MORE:
+            if (mpptVoltage >= targetVoltage) {
+                // still above the target voltage, we try to increase the power
+                addPower = 2*_powerStep;
+            } else {
+                // below the target voltage, we need less power
+                addPower = -_powerStep;     // less power
+                _surplusState = SurplusState::REDUCE_POWER;
+            }
+            break;
+
+        case SurplusState::REDUCE_POWER:
+            if (mpptVoltage >= targetVoltage) {
+                // we are in target and can keep the last surplus power value
+                _inTargetTime = millis();
+                _surplusState = SurplusState::IN_TARGET;
+            } else {
+                // still below the target voltage, we need less power
+                addPower = -_powerStep;
+            }
+            break;
+
+        case SurplusState::MAXIMUM_POWER:
+        case SurplusState::IN_TARGET:
+            // note: here we use both the actual and the average battery voltage
+            if ((avgMPPTVoltage >= targetVoltage) || (mpptVoltage >= targetVoltage)) {
+                // we try to increase the power after a time out of 60 sec
+                if ((millis() - _inTargetTime) > TIME_OUT) {
+                    addPower = _powerStep;   // try if more power is possible
+                    _surplusState = SurplusState::TRY_MORE;
+                }
+                // we reached the target and can check, how many polarity changes we needed
+                handleQualityCounter();
+            } else {
+                // out of the target voltage we must reduce the power
+                addPower = -_powerStep;
+                _surplusState = SurplusState::REDUCE_POWER;
+            }
+            break;
+
+        default:
+                addPower = 0;
+                _surplusState = SurplusState::IDLE;
+
+    }
+    _surplusPower += addPower;
+
+    // we do not go above the maximum power limit
+    if (_surplusPower > config.PowerLimiter.UpperPowerLimit) {
+        _surplusPower = config.PowerLimiter.UpperPowerLimit;
+        _surplusState = SurplusState::MAXIMUM_POWER;
+    }
+
+    // we do not go below the requested power
+    auto backPower = _surplusPower;
+    if (requestedPower > _surplusPower) {
+        backPower = _surplusPower = requestedPower;
+    } else {
+
+        // quality check: we count every power step polarity change ( + to -  and - to +)
+        // to give an indication of the regulation quality
+        if (((_lastAddPower < 0) && (addPower > 0)) || ((_lastAddPower > 0) && (addPower < 0)))
+            _qualityCounter++;
+        _lastAddPower = addPower;
+    }
+
+    // print some basic information
+    auto qualityAVG = _qualityAVG.getAverage();
+    Text text = Text::Q_BAD;
+    if ((qualityAVG >= 0.0f) && (qualityAVG <= 1.0f)) text = Text::Q_EXCELLENT;
+    if ((qualityAVG > 1.0f) && (qualityAVG <= 2.0f)) text = Text::Q_GOOD;
+    MessageOutput.printf("%s Mode: %s, Quality: %s, Surplus power: %iW, Requested power: %iW, Returned power: %iW\r\n",
+        getText(Text::T_HEAD).data(), getStatusText(_surplusState).data(), getText(text).data(),
+        _surplusPower, requestedPower, backPower);
+
+
+    // todo: maybe we can delete some additional informations after the test phase
+    if (config.PowerLimiter.VerboseLogging || MODULE_DEBUG >= 2) {
+        MessageOutput.printf("%s Target voltage: %0.2fV, Battery voltage: %0.2f, Average battery voltage: %0.3fV\r\n",
+            getText(Text::T_HEAD).data(), targetVoltage, mpptVoltage, avgMPPTVoltage);
+
+        MessageOutput.printf("%s Regulation quality: %s, Average: %0.2f (Min: %0.0f, Max: %0.0f, Amount: %i)\r\n",
+            getText(Text::T_HEAD).data(), getText(text).data(),
+            _qualityAVG.getAverage(), _qualityAVG.getMin(), _qualityAVG.getMax(), _qualityAVG.getCounts());
+    }
+
+    return backPower;
+}
+
+
+/*
+ * getStatusText()
+ * return: string according to current status
+ */
+frozen::string const& SurplusPowerClass::getStatusText(SurplusPowerClass::SurplusState state)
+{
+    static const frozen::string missing = "programmer error: missing status text";
+
+    static const frozen::map<SurplusState, frozen::string, 5> texts = {
+        { SurplusState::IDLE, "Idle" },
+        { SurplusState::TRY_MORE, "Try more power" },
+        { SurplusState::REDUCE_POWER, "Reduce power" },
+        { SurplusState::IN_TARGET, "In target range" },
+        { SurplusState::MAXIMUM_POWER, "Maximum power" }
+    };
+
+    auto iter = texts.find(state);
+    if (iter == texts.end()) { return missing; }
+
+    return iter->second;
+}
+
+
+/*
+ * getText()
+ * return: string according to current status
+ */
+frozen::string const& SurplusPowerClass::getText(SurplusPowerClass::Text tNr)
+{
+    static const frozen::string missing = "programmer error: missing status text";
+
+    static const frozen::map<Text, frozen::string, 5> texts = {
+        { Text::Q_NODATA, "Insufficient data" },
+        { Text::Q_EXCELLENT, "Excellent" },
+        { Text::Q_GOOD, "Good" },
+        { Text::Q_BAD, "Bad" },
+        { Text::T_HEAD, "[Surplus-Mode]"}
+    };
+
+    auto iter = texts.find(tNr);
+    if (iter == texts.end()) { return missing; }
+
+    return iter->second;
+}


### PR DESCRIPTION
Surplus-Power-Mode

**Was macht der "Surplus-Power-Mode"**
Der "Surplus-Power-Mode" regelt die Inverter-Leistung auf Basis der überschüssigen Solar-Leistung. Überschüssige Solar-Leistung ist immer dann vorhanden, wenn die Batterie (fast) voll ist und die verfügbare Solar-Leistung höher ist als die Leistung, die im Haushalt verbraucht wird.

Weitere Infos sind im PDF zu finden

[SurplusEnergyMode.pdf](https://github.com/user-attachments/files/16628076/SurplusEnergyMode.pdf)
