### PR TITLE
Feature: Battery Fully Charged Time

### DIFF
--- a/include/battery/Controller.h
+++ b/include/battery/Controller.h
@@ -16,6 +16,9 @@ public:
 
     float getDischargeCurrentLimit();
 
+    void serializeRTD(JsonObject const&) const;
+    void deserializeRTD(JsonObject const&);
+
     std::shared_ptr<Stats const> getStats() const;
 
 private:

--- a/include/battery/Provider.h
+++ b/include/battery/Provider.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 namespace Batteries {
 
@@ -15,6 +16,7 @@ public:
     virtual void deinit() = 0;
     virtual void loop() = 0;
     virtual std::shared_ptr<Stats> getStats() const = 0;
+    virtual void setFullyChargedEpoch(std::optional<time_t>) = 0;
     virtual std::shared_ptr<HassIntegration> getHassIntegration() = 0;
 };
 

--- a/include/battery/Stats.h
+++ b/include/battery/Stats.h
@@ -35,6 +35,10 @@ public:
     float getChargeCurrentLimit() const { return _chargeCurrentLimit; };
     uint32_t getChargeCurrentLimitAgeSeconds() const { return (millis() - _lastUpdateChargeCurrentLimit) / 1000; }
 
+    std::optional<time_t> getSoCFullEpoch() const { return _oSoCFullEpoch; }
+    void setSoCFullEpoch(std::optional<time_t> full) { _oSoCFullEpoch = full; }
+    virtual void checkSoCFullEpoch(void);
+
     // convert stats to JSON for web application live view
     virtual void getLiveViewData(JsonVariant& root) const;
 
@@ -175,6 +179,7 @@ private:
     uint32_t _lastMqttPublish = 0;
     float _soc = 0;
     uint8_t _socPrecision = 0; // decimal places
+    std::optional<time_t> _oSoCFullEpoch = std::nullopt;
     uint32_t _lastUpdateSoC = 0;
     float _voltage = 0; // total battery pack voltage
     uint32_t _lastUpdateVoltage = 0;

--- a/include/battery/jbdbms/Provider.h
+++ b/include/battery/jbdbms/Provider.h
@@ -20,6 +20,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/jkbms/Provider.h
+++ b/include/battery/jkbms/Provider.h
@@ -23,6 +23,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/mqtt/Provider.h
+++ b/include/battery/mqtt/Provider.h
@@ -15,6 +15,7 @@ public:
     void deinit() final;
     void loop() final { return; } // this class is event-driven
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<HassIntegration> getHassIntegration() final { return nullptr; }
 
 private:

--- a/include/battery/pylontech/Provider.h
+++ b/include/battery/pylontech/Provider.h
@@ -16,6 +16,7 @@ public:
     void onMessage(twai_message_t rx_message) final;
 
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/pytes/Provider.h
+++ b/include/battery/pytes/Provider.h
@@ -16,6 +16,7 @@ public:
     void onMessage(twai_message_t rx_message) final;
 
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/sbs/Provider.h
+++ b/include/battery/sbs/Provider.h
@@ -16,6 +16,7 @@ public:
     void onMessage(twai_message_t rx_message) final;
 
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/victronsmartshunt/Provider.h
+++ b/include/battery/victronsmartshunt/Provider.h
@@ -15,6 +15,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/include/battery/victronsmartshunt/Stats.h
+++ b/include/battery/victronsmartshunt/Stats.h
@@ -12,6 +12,7 @@ public:
     void mqttPublish() const final;
 
     void updateFrom(VeDirectShuntController::data_t const& shuntData);
+    void checkSoCFullEpoch(void) final;
 
 private:
     float _temperature;

--- a/include/battery/zendure/Provider.h
+++ b/include/battery/zendure/Provider.h
@@ -17,6 +17,7 @@ public:
     void deinit() final;
     void loop() final;
     std::shared_ptr<::Batteries::Stats> getStats() const final { return _stats; }
+    void setFullyChargedEpoch(std::optional<time_t> chargeEpoch) final { _stats->setSoCFullEpoch(chargeEpoch); }
     std::shared_ptr<::Batteries::HassIntegration> getHassIntegration() final { return _hassIntegration; }
 
 private:

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -21,6 +21,7 @@
 #include <Utils.h>
 #include <LittleFS.h>
 #include <LogHelper.h>
+#include <battery/Controller.h>
 #include "RuntimeData.h"
 
 
@@ -109,7 +110,7 @@ bool RuntimeClass::write(uint16_t const freezeMinutes)
         info["save_epoch"] = nextEpoch;
 
         // ensure any additional shared data added here remains under the existing mutex protection
-
+        Battery.serializeRTD(doc["battery"].to<JsonObject>());
 
         if (!Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
             return cleanExit(false, "JSON alloc fault, skipping write");
@@ -167,11 +168,10 @@ bool RuntimeClass::read(ReadMode const mode)
     // deserialize additional runtime data here, prepare default values and protect the shared data with a mutex
     // use ReadMode::START_UP for all data that can be initialized during startup
     if (mode == ReadMode::START_UP) {
-        ;
+        Battery.deserializeRTD(doc["battery"]);
     } else {
         ;
     }
-
 
     if (fRuntime) { fRuntime.close(); }
     if (readOk) {

--- a/src/battery/Controller.cpp
+++ b/src/battery/Controller.cpp
@@ -10,6 +10,7 @@
 #include <battery/zendure/Provider.h>
 #include <Configuration.h>
 #include <LogHelper.h>
+#include <Utils.h>
 
 #undef TAG
 static const char* TAG = "battery";
@@ -94,6 +95,8 @@ void Controller::loop()
 
     _upProvider->loop();
 
+    _upProvider->getStats()->checkSoCFullEpoch();
+
     _upProvider->getStats()->mqttLoop();
 
     auto spHassIntegration = _upProvider->getHassIntegration();
@@ -150,6 +153,28 @@ float Controller::getDischargeCurrentLimit()
     };
 
     return std::min(getConfiguredLimit(), getBatteryLimit());
+}
+
+void Controller::serializeRTD(JsonObject const& obj) const
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    if (!_upProvider) {
+        obj["fully_charged_epoch"] = 0; // no battery in the system
+        return;
+    }
+
+    obj["fully_charged_epoch"] = _upProvider->getStats()->getSoCFullEpoch().value_or(0);
+}
+
+void Controller::deserializeRTD(JsonObject const& obj)
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    if (!_upProvider) { return; } // no battery, nothing to do
+
+    time_t fullEpoch =  obj["fully_charged_epoch"] | 0;
+    _upProvider->setFullyChargedEpoch(fullEpoch == 0 ? std::nullopt : std::make_optional(fullEpoch));
 }
 
 } // namespace Batteries

--- a/src/battery/Stats.cpp
+++ b/src/battery/Stats.cpp
@@ -3,6 +3,7 @@
 #include <battery/Stats.h>
 #include <Configuration.h>
 #include <MqttSettings.h>
+#include "Utils.h"
 
 namespace Batteries {
 
@@ -46,6 +47,20 @@ void Stats::getLiveViewData(JsonVariant& root) const
 
     if (isSoCValid()) {
         addLiveViewValue(root, "SoC", _soc, "%", _socPrecision);
+    }
+
+    if (_oSoCFullEpoch.has_value()) {
+        tm fullTime;
+        time_t nowTime;
+        localtime_r(&_oSoCFullEpoch.value(), &fullTime);
+        fullTime.tm_hour = fullTime.tm_min = fullTime.tm_sec = 0; // always start from midnight
+        if (Utils::getEpoch(&nowTime, 5)) {
+            auto midnightEpoch = mktime(&fullTime);
+            if ((midnightEpoch != -1) && (nowTime >= midnightEpoch)) {
+                auto days = static_cast<uint16_t>(difftime(nowTime, midnightEpoch) / (60.0 * 60.0 * 24.0));
+                addLiveViewValue(root, "fullyChargedDays", days, "days", 0);
+            }
+        }
     }
 
     if (isVoltageValid()) {
@@ -118,6 +133,23 @@ void Stats::mqttPublish() const
 
     if (isChargeCurrentLimitValid()) {
         MqttSettings.publish("battery/settings/chargeCurrentLimitation", String(_chargeCurrentLimit));
+    }
+}
+
+void Stats::checkSoCFullEpoch(void)
+{
+    static uint32_t lastUpdate = 0;
+
+    if (lastUpdate == _lastUpdate) { return; } // fast exit from already processed values
+    lastUpdate = _lastUpdate;
+    time_t nowEpoch;
+
+    // The goal is to record the time when we reach 100% SoC, to record the time as long as we have 100% SoC,
+    // and to maintain the time until we reach 100% SoC again.
+    if (isSoCValid() && (getSoCAgeSeconds() <= 30) && (getSoC() >= 100.0f) && Utils::getEpoch(&nowEpoch, 5)) {
+        if (!_oSoCFullEpoch.has_value() || (nowEpoch > _oSoCFullEpoch.value())) {
+            _oSoCFullEpoch = nowEpoch;
+        }
     }
 }
 

--- a/src/battery/victronsmartshunt/Stats.cpp
+++ b/src/battery/victronsmartshunt/Stats.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include <MqttSettings.h>
 #include <battery/victronsmartshunt/Stats.h>
+#include <Utils.h>
 
 namespace Batteries::VictronSmartShunt {
 
@@ -65,6 +66,26 @@ void Stats::mqttPublish() const {
     MqttSettings.publish("battery/lastFullCharge", String(_lastFullCharge));
     MqttSettings.publish("battery/midpointVoltage", String(_midpointVoltage));
     MqttSettings.publish("battery/midpointDeviation", String(_midpointDeviation));
+}
+
+void Stats::checkSoCFullEpoch(void) {
+    static uint32_t lastUpdate = 0;
+
+    if (lastUpdate == _lastUpdate) { return; } // fast exit from already processed values
+    lastUpdate = _lastUpdate;
+    time_t nowEpoch;
+
+    if (Utils::getEpoch(&nowEpoch, 5)) {
+
+        // reverse calculation to get 'fully charged epoch' from the smart shunt duration value
+        auto shuntEpoch = std::make_optional(nowEpoch - static_cast<time_t>(_lastFullCharge * 60));
+        auto lastEpoch = getSoCFullEpoch();
+
+        // We only update if the value is not in the future and we don't have epoch yet or we have a newer value
+        if ((shuntEpoch.value() <= nowEpoch) && (!lastEpoch.has_value() || (shuntEpoch.value() > lastEpoch))) {
+            setSoCFullEpoch(shuntEpoch);
+        }
+    }
 }
 
 } // namespace Batteries::VictronSmartShunt

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -1147,6 +1147,7 @@
         "Value": "Wert",
         "Unit": "@:base.Unit",
         "SoC": "Ladezustand (SoC)",
+        "fullyChargedDays": "Tage seit Volladung",
         "stateOfHealth": "Batteriezustand (SoH)",
         "voltage": "Spannung",
         "current": "Strom",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -1151,6 +1151,7 @@
         "Value": "Value",
         "Unit": "@:base.Unit",
         "SoC": "State of Charge",
+        "fullyChargedDays": "Days since fully charged",
         "stateOfHealth": "State of Health",
         "voltage": "Voltage",
         "current": "Current",


### PR DESCRIPTION
This pull request adds a new feature to the battery providers. Detects when the battery is fully charged and stores the time in the runtime data.

- General detection for all battery provider that deliver SoC information.
- Special version for the provider 'Victron Smart Shunt' (fully charged time already availabe)
- Prepared to add special versions to other battery providers if required by virtual overload
- Display the value in the live view, but only if the information is available
- The value is automatically stored in the runtime data JSON-File
- Getter function Battery.getStats()->getFullyChargedTime()

Note
- The 'Battery Fully Charged Time' is required for the 'Recharge Helper' which is part of the upcoming improved 'Battery Guard'
- There is currently no solution for battery providers who do not provide SoC information. A possible solution would be to use battery voltage or battery charger state.

Testing
To test the PR on your system, follow these steps:

- Update your system with the new firmware.
- On systems with a 'Victron Smart Shunt' you should immediately see the information in the WebUI.
- On the other battery provider we must wait until we reach 100% SoC

<img width="300" height="200" alt="grafik" src="https://github.com/user-attachments/assets/4ca13a81-f839-4284-94d5-326b6d8314ae" />
