### PR TITLE
Enable standby for battery powerd inverter

### DIFF
--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -640,6 +640,14 @@ uint16_t PowerLimiterClass::updateInverterLimits(uint16_t powerRequested,
 
     if (matchingInverters.empty()) { return 0; }
 
+    // if we have battery-powered inverters and the battery is below the stop threshold,
+    // we set all into standby
+    if ((matchingInverters[0]->isBatteryPowered()) && (_batteryState == BatteryState::STOP)) {
+        for (auto pInv : matchingInverters) { pInv->standby(); }
+        DTU_LOGD("battery below stop threshold, all battery-powered inverters are stopped");
+        return 0;
+    }
+
     int32_t diff = powerRequested - producing;
 
     auto const& config = Configuration.get();

--- a/src/PowerLimiterBatteryInverter.cpp
+++ b/src/PowerLimiterBatteryInverter.cpp
@@ -9,7 +9,7 @@ uint16_t PowerLimiterBatteryInverter::getMaxReductionWatts(bool allowStandby) co
 
     if (!isProducing()) { return 0; }
 
-    if (allowStandby) { return getCurrentOutputAcWatts(); }
+    if (allowStandby && _config.AllowStandby) { return getCurrentOutputAcWatts(); }
 
     if (getCurrentOutputAcWatts() <= _config.LowerPowerLimit) { return 0; }
 
@@ -44,11 +44,11 @@ uint16_t PowerLimiterBatteryInverter::applyReduction(uint16_t reduction, bool al
 
     auto low = std::min(getCurrentLimitWatts(), getCurrentOutputAcWatts());
     if (low <= _config.LowerPowerLimit) {
-        if (allowStandby) {
+        if (allowStandby && _config.AllowStandby) {
             standby();
             return std::min(reduction, getCurrentOutputAcWatts());
         }
-        return 0;
+        return 0; // todo @SW-Niko: would it be more safe to set the lower limit again?
     }
 
     if ((getCurrentLimitWatts() - _config.LowerPowerLimit) >= reduction) {
@@ -56,7 +56,7 @@ uint16_t PowerLimiterBatteryInverter::applyReduction(uint16_t reduction, bool al
         return reduction;
     }
 
-    if (allowStandby) {
+    if (allowStandby && _config.AllowStandby) {
         standby();
         return std::min(reduction, getCurrentOutputAcWatts());
     }

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -729,7 +729,7 @@
         "UpperPowerLimit": "Maximales Leistungslimit",
         "UpperPowerLimitHint": "Der Wechselrichter wird stets so eingestellt, dass höchstens diese Ausgangsleistung erreicht wird. Dieser Wert muss so gewählt werden, dass die Strombelastbarkeit der AC-Anschlussleitungen eingehalten wird.",
         "AllowStandby": "Standby erlauben",
-        "AllowStandbyHint": "Erlaubt dem Wechselrichter in Standby zu gehen, wenn das berechnete Leistungslimit unter dem minimalen Leistungslimit liegt.",
+        "AllowStandbyHint": "Erlaubt dem Wechselrichter in Standby zu gehen, wenn das berechnete Leistungslimit unter dem minimalen Leistungslimit liegt. Ansonsten wird der Wechselrichter auf das minimale Leistungslimit gesetzt.",
         "SocThresholds": "Batterie State of Charge (SoC) Schwellwerte",
         "IgnoreSoc": "Nur Spannungs-Schwellwerte nutzen",
         "IgnoreSocHint": "Falls aktiviert werden nur die Spannungs-Schwellwerte berücksichtigt. Deaktiviere diesen Schalter, um Batterie State of Charge (SoC) Schwellwerte zu konfigurieren (nicht empfohlen, da der SoC-Wert häufig ungenau ist).",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -729,7 +729,7 @@
         "UpperPowerLimit": "Maximum Power Limit",
         "UpperPowerLimitHint": "The inverter is always set such that no more than this output power is achieved. This value must be selected to comply with the current carrying capacity of the AC connection cables.",
         "AllowStandby": "Allow Standby",
-        "AllowStandbyHint": "Allow the inverter to go into standby if the calculated power limit is below the minimum power limit.",
+        "AllowStandbyHint": "Allow the inverter to go into standby if the calculated power limit is below the minimum power limit. Otherwise, the inverter will be set to the minimum power limit.",
         "SocThresholds": "Battery State of Charge (SoC) Thresholds",
         "IgnoreSoc": "Use Voltage Thresholds Only",
         "IgnoreSocHint": "When enabled, only voltage thresholds are considered. Disable this switch to configure and use battery State of Charge (SoC) thresholds (not recommended as the SoC value is often inaccurate).",

--- a/webapp/src/views/PowerLimiterAdminView.vue
+++ b/webapp/src/views/PowerLimiterAdminView.vue
@@ -161,7 +161,7 @@
                         <InputElement
                             :label="$t('powerlimiteradmin.AllowStandby')"
                             :tooltip="$t('powerlimiteradmin.AllowStandbyHint')"
-                            v-if="inv.power_source == 2"
+                            v-if="inv.power_source == 2 || inv.power_source == 0"
                             v-model="inv.allow_standby"
                             type="checkbox"
                             wide


### PR DESCRIPTION
Add option enable/disable Allow Standby to battery powered inverter.

<img width="350" height="100" alt="grafik" src="https://github.com/user-attachments/assets/2a55a6d2-d418-46ac-80b0-2e1e0777e451" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AllowStandby option now available for Battery-powered inverters (previously SmartBuffer only)

* **Bug Fixes**
  * Enhanced standby logic for battery-powered inverters with stricter condition checks

* **Documentation**
  * Updated help text clarifying AllowStandby behavior and minimum power limit fallback handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->