### PR TITLE
StableTime: improve responsiveness on power change

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -86,6 +86,9 @@ private:
     bool _fullSolarPassThroughActive = false;
     float _loadCorrectedVoltage = 0.0f;
 
+    uint32_t _lastPowerMeterUpdate = 0; // timestamp of last power meter update
+    uint16_t _lastConsumptionPower = 0; // last calculated consumption power
+
     frozen::string const& getStatusText(Status status) const;
     void announceStatus(Status status);
     void reloadConfig();
@@ -93,7 +96,7 @@ private:
     float getBatteryVoltage(bool log = false) const;
     uint16_t dcPowerBusToInverterAc(uint16_t dcPower) const;
     void unconditionalFullSolarPassthrough();
-    uint16_t calcTargetOutput() const;
+    uint16_t calcTargetOutput(bool loggingRequested = true) const;
     using inverter_filter_t = std::function<bool(PowerLimiterInverter const&)>;
     uint16_t updateInverterLimits(uint16_t powerRequested, inverter_filter_t filter, std::string const& filterExpression);
     uint16_t calcPowerBusUsage(uint16_t powerRequested) const;
@@ -114,6 +117,8 @@ private:
     float getPrioritySoCStopThreshold(void) const;
     float getPriorityVoltageStartThreshold(void) const;
     float getPriorityVoltageStopThreshold(void) const;
+
+    bool isConsumptionPowerChangeSufficient();
 };
 
 extern PowerLimiterClass PowerLimiter;

--- a/include/PowerLimiterInverter.h
+++ b/include/PowerLimiterInverter.h
@@ -72,6 +72,9 @@ public:
     bool isReachable() const { return _spInverter->isReachable(); }
     bool isProducing() const { return _spInverter->isProducing(); }
 
+    uint16_t getLowerPowerLimit() const { return _config.LowerPowerLimit; }
+    uint16_t getUpperPowerLimit() const { return _config.UpperPowerLimit; }
+
     uint64_t getSerial() const { return _config.Serial; }
     char const* getSerialStr() const { return _serialStr; }
     bool isBehindPowerMeter() const { return _config.IsBehindPowerMeter; }

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -216,7 +216,9 @@ void PowerLimiterClass::loop()
 
     // since _lastCalculation and _calculationBackoffMs are initialized to
     // zero, this test is passed the first time the condition is checked.
-    if ((millis() - _lastCalculation) < _calculationBackoffMs) {
+    // to improve responsiveness, we ignore the backoff time if the change of the power consumption
+    // is sufficient high enough to do a complete recalculation immediately.
+    if (!isConsumptionPowerChangeSufficient() && ((millis() - _lastCalculation) < _calculationBackoffMs)) {
         return announceStatus(Status::Stable);
     }
 
@@ -568,7 +570,7 @@ uint8_t PowerLimiterClass::getPowerLimiterState() const
         ? PL_UI_STATE_USE_SOLAR_AND_BATTERY : PL_UI_STATE_USE_SOLAR_ONLY;
 }
 
-uint16_t PowerLimiterClass::calcTargetOutput() const
+uint16_t PowerLimiterClass::calcTargetOutput(bool loggingRequested) const
 {
     auto const& config = Configuration.get();
     auto targetConsumption = config.PowerLimiter.TargetPowerConsumption;
@@ -577,9 +579,11 @@ uint16_t PowerLimiterClass::calcTargetOutput() const
     auto meterValid = PowerMeter.isDataValid();
     auto meterValue = PowerMeter.getPowerTotal();
 
-    DTU_LOGD("targeting %d W, base load is %u W, power meter reads %.1f W (%s)",
-            targetConsumption, baseLoad, meterValue,
-            (meterValid?"valid":"stale"));
+    if (loggingRequested) {
+        DTU_LOGD("targeting %d W, base load is %u W, power meter reads %.1f W (%s)",
+                targetConsumption, baseLoad, meterValue,
+                (meterValid?"valid":"stale"));
+    }
 
     if (!meterValid) { return baseLoad; }
 
@@ -1023,4 +1027,81 @@ float PowerLimiterClass::getPriorityVoltageStartThreshold(void) const
 float PowerLimiterClass::getPriorityVoltageStopThreshold(void) const
 {
     return BatteryGuard.getVoltageStopThreshold().value_or(Configuration.get().PowerLimiter.VoltageStopThreshold);
+}
+
+/*
+ * returns true if the consumption power has changed more as the double hysteresis since the last check
+ * Note: we do not handle all cases. For example if all inverters are in standby and will be switched on!
+ */
+bool PowerLimiterClass::isConsumptionPowerChangeSufficient() {
+
+    // if power meter data is not valid, we abort
+    if (!PowerMeter.isDataValid()) { return false; }
+
+    // if the power meter data has not changed since the last check, we abort
+    auto newPowerMeterUpdate = PowerMeter.getLastUpdate();
+    if (newPowerMeterUpdate == _lastPowerMeterUpdate) { return false; }
+
+    // we got new power meter data, we can do a fast pre check if the consumption power change is sufficient
+    auto newConsumptionPower = calcTargetOutput(false);
+    auto totalUpperPower = Configuration.get().PowerLimiter.TotalUpperPowerLimit;
+    uint16_t hysteresis = Configuration.get().PowerLimiter.TargetPowerConsumptionHysteresis * 2; // double the hysteresis
+
+    // we calculate the upper power limit of all active inverters and the lower power limit if only one inverter is producing.
+    uint16_t lowerPowerOneActiveInverter = totalUpperPower;
+    uint16_t upperPowerAllActiveInverter = 0;
+    bool hasActiveInverter = false;
+    for (auto const& upInv : _inverters) {
+        if (!upInv->isEligible()) { continue; }
+        if (!upInv->isProducing()) { continue; }
+
+        hasActiveInverter = true;
+        if (upInv->getLowerPowerLimit() < lowerPowerOneActiveInverter) { lowerPowerOneActiveInverter = upInv->getLowerPowerLimit(); }
+        upperPowerAllActiveInverter += upInv->getUpperPowerLimit();
+    }
+    upperPowerAllActiveInverter = std::min(upperPowerAllActiveInverter, totalUpperPower);
+
+    // if we don't have any active inverter, we abort
+    if (!hasActiveInverter) { return false; }
+
+    // the power change is sufficient if we are at least with one value inside the lower and upper power limits
+    // and the change is bigger than the double of the hysteresis.
+    auto result = true;
+    if (((_lastConsumptionPower > upperPowerAllActiveInverter) && (newConsumptionPower > upperPowerAllActiveInverter))
+        || ((_lastConsumptionPower < lowerPowerOneActiveInverter) && (newConsumptionPower < lowerPowerOneActiveInverter))
+        || ((std::abs(newConsumptionPower - _lastConsumptionPower) < hysteresis))) {
+        result = false;
+    }
+
+    // todo: remove information log after testing
+    static uint32_t lastLogTime = 0;
+    static uint32_t saveTimeTotal = 0;
+    static float exportEnergy = 0.0f;
+    static float importEnergy = 0.0f;
+    if (result && (_lastCalculation > 0)) {
+        if ((millis() - _lastCalculation) < _calculationBackoffMs) {
+            auto saveTime = _calculationBackoffMs - millis() + _lastCalculation;
+            saveTimeTotal += saveTime;
+            auto newPower = (newConsumptionPower > upperPowerAllActiveInverter) ? upperPowerAllActiveInverter : newConsumptionPower;
+            auto oldPower = (_lastConsumptionPower > upperPowerAllActiveInverter) ? upperPowerAllActiveInverter : _lastConsumptionPower;
+            float diffPower = newPower - oldPower;
+            if (diffPower >= 0.0f) {
+                importEnergy += diffPower * (saveTime / 1000.0f);   // in watt-seconds
+            } else {
+                exportEnergy += -diffPower * (saveTime / 1000.0f);  // in watt-seconds
+            }
+        }
+    }
+    if (millis() - lastLogTime > 30*1000) {
+        DTU_LOGI("Stable-Time: save time total: %us, less export energy: %.3fWh, less import energy: %.3fWh",
+            saveTimeTotal / 1000, exportEnergy / (60.0f * 60.0f), importEnergy / (60.0f * 60.0f));
+        DTU_LOGI("Stable-Time: power range: %uW - %uW, minimum power change: %uW",
+            lowerPowerOneActiveInverter, upperPowerAllActiveInverter, hysteresis);
+        lastLogTime = millis();
+    }
+    // todo: remove information log after testing
+
+    _lastPowerMeterUpdate = newPowerMeterUpdate;
+    _lastConsumptionPower = newConsumptionPower;
+    return result;
 }


### PR DESCRIPTION
In case of fast sufficient power consumption changes we ignore the backoff time. 
This saves 0-1 sec reaction time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Smarter backoff: recalculations now skip early exit when measured consumption changes are significant, reducing missed adjustments.
  * Reduced diagnostic noise: target calculation logs emitted only when requested to limit debug output.
  * Better stability detection: refined logic considers recent meter updates and inverter bounds to avoid unnecessary adjustments.

* **New Features**
  * Added inverter lower/upper power limit accessors for status and UI use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->