### PR TITLE
Feature: PowerMeter / 500ms interval-time and extended logging

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -10,7 +10,7 @@
 
 #define CONFIG_FILENAME "/config.json"
 #define CONFIG_VERSION 0x00011e00 // 0.1.30 // make sure to clean all after change
-#define CONFIG_VERSION_ONBATTERY 8
+#define CONFIG_VERSION_ONBATTERY 9
 
 #define WIFI_MAX_SSID_STRLEN 32
 #define WIFI_MAX_PASSWORD_STRLEN 64
@@ -128,7 +128,7 @@ struct POWERMETER_HTTP_JSON_VALUE_T {
 using PowerMeterHttpJsonValue = struct POWERMETER_HTTP_JSON_VALUE_T;
 
 struct POWERMETER_HTTP_JSON_CONFIG_T {
-    uint32_t PollingInterval;
+    uint32_t PollingIntervalMs;
     bool IndividualRequests;
     PowerMeterHttpJsonValue Values[POWERMETER_HTTP_JSON_MAX_VALUES];
 };

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -6,6 +6,7 @@
 #include "NetworkSettings.h"
 #include "Utils.h"
 #include "defaults.h"
+#include <algorithm>
 #include <LittleFS.h>
 #include <esp_log.h>
 #include <nvs_flash.h>
@@ -101,7 +102,7 @@ void ConfigurationClass::serializePowerMeterSerialSdmConfig(PowerMeterSerialSdmC
 
 void ConfigurationClass::serializePowerMeterHttpJsonConfig(PowerMeterHttpJsonConfig const& source, JsonObject& target, bool includeCredentials)
 {
-    target["polling_interval"] = source.PollingInterval;
+    target["polling_interval_ms"] = source.PollingIntervalMs;
     target["individual_requests"] = source.IndividualRequests;
 
     JsonArray values = target["values"].to<JsonArray>();
@@ -573,7 +574,8 @@ void ConfigurationClass::deserializePowerMeterSerialSdmConfig(JsonObject const& 
 
 void ConfigurationClass::deserializePowerMeterHttpJsonConfig(JsonObject const& source, PowerMeterHttpJsonConfig& target)
 {
-    target.PollingInterval = source["polling_interval"] | POWERMETER_POLLING_INTERVAL;
+    target.PollingIntervalMs = source["polling_interval_ms"] | POWERMETER_POLLING_INTERVAL * 1000;
+    target.PollingIntervalMs = std::clamp(target.PollingIntervalMs, 100u, 15000u);
     target.IndividualRequests = source["individual_requests"] | false;
 
     JsonArray values = source["values"].as<JsonArray>();
@@ -1294,6 +1296,13 @@ void ConfigurationClass::migrateOnBattery()
         config.GridCharger.Huawei.InputCurrentLimit = huawei["input_current_limit"] | GRIDCHARGER_HUAWEI_INPUT_CURRENT_LIMIT;
         config.GridCharger.Huawei.FanOnlineFullSpeed = huawei["fan_online_full_speed"] | GRIDCHARGER_HUAWEI_FAN_ONLINE_FULL_SPEED;
         config.GridCharger.Huawei.FanOfflineFullSpeed = huawei["fan_offline_full_speed"] | GRIDCHARGER_HUAWEI_FAN_OFFLINE_FULL_SPEED;
+    }
+
+    if (config.Cfg.VersionOnBattery < 9) {
+        // new unit is now milliseconds
+        JsonObject httpJson = doc["powermeter"]["http_json"];
+        config.PowerMeter.HttpJson.PollingIntervalMs = httpJson["polling_interval"] | POWERMETER_POLLING_INTERVAL;
+        config.PowerMeter.HttpJson.PollingIntervalMs *= 1000;
     }
 
     f.close();

--- a/src/HttpGetter.cpp
+++ b/src/HttpGetter.cpp
@@ -5,6 +5,7 @@
 #include "mbedtls/md5.h"
 #include <base64.h>
 #include <ESPmDNS.h>
+#include <algorithm>
 
 template<typename... Args>
 void HttpGetter::logError(char const* format, Args... args) {
@@ -115,7 +116,10 @@ HttpRequestResult HttpGetter::performGetRequest()
 
     upTmpHttpClient->setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
     upTmpHttpClient->setUserAgent("OpenDTU-OnBattery");
-    upTmpHttpClient->setConnectTimeout(_config.Timeout);
+
+    // _config.Timeout is used for both connection and response. Usually the connection is the slower part.
+    // We enforce a minimum timeout for the connection phase of 2000ms to avoid failed requests
+    upTmpHttpClient->setConnectTimeout(std::max(_config.Timeout, static_cast<uint16_t>(2000)));
     upTmpHttpClient->setTimeout(_config.Timeout);
     for (auto const& h : _additionalHeaders) {
         upTmpHttpClient->addHeader(h.first.c_str(), h.second.c_str());

--- a/src/powermeter/json/http/Provider.cpp
+++ b/src/powermeter/json/http/Provider.cpp
@@ -7,6 +7,7 @@
 #include <base64.h>
 #include <ESPmDNS.h>
 #include <LogHelper.h>
+#include "Statistic.h"
 
 #undef TAG
 static const char* TAG = "powerMeter";
@@ -82,28 +83,78 @@ void Provider::pollingLoop()
 {
     std::unique_lock<std::mutex> lock(_pollingMutex);
 
+    // debug variables
+    uint32_t lastPrint = 0;
+    uint16_t dataCounter = 0;
+    uint16_t identicalDataCounter = 0;
+    uint16_t errorCount = 0;
+    float lastTotalPower = 0.0f;
+    WeightedAVG<uint32_t> avgPollTime{50};     // average poll time
+    WeightedAVG<uint32_t> avgIntervalTime{50}; // average interval time
+
     while (!_stopPolling) {
-        auto elapsedMillis = millis() - _lastPoll;
-        auto intervalMillis = _cfg.PollingInterval * 1000;
+        uint32_t elapsedMillis = millis() - _lastPoll;
+        uint32_t intervalMillis = _cfg.PollingIntervalMs;
         if (_lastPoll > 0 && elapsedMillis < intervalMillis) {
             auto sleepMs = intervalMillis - elapsedMillis;
+            sleepMs = std::max(sleepMs, intervalMillis / 2); // to avoid too fast polling
             _cv.wait_for(lock, std::chrono::milliseconds(sleepMs),
                     [this] { return _stopPolling; }); // releases the mutex
             continue;
         }
 
-        _lastPoll = millis();
+        // record the average interval time
+        uint32_t pollStart = millis();
+        if (_lastPoll > 0) { avgIntervalTime.addNumber(pollStart - _lastPoll); }
+
+        _lastPoll = pollStart; // used for calculating the next polling interval
 
         lock.unlock(); // polling can take quite some time
         auto res = poll();
         lock.lock();
 
+        uint32_t pollEnd = millis();
+
         if (std::holds_alternative<String>(res)) {
             DTU_LOGE("%s", std::get<String>(res).c_str());
-            continue;
+            errorCount++;
+        } else {
+            float currentTotalPower = getPowerTotal();
+            if ((currentTotalPower == lastTotalPower) && (currentTotalPower != 0.0f)) { identicalDataCounter++; }
+            lastTotalPower = currentTotalPower;
+
+            DTU_LOGD("New total: %.2fW", currentTotalPower);
         }
 
-        DTU_LOGD("New total: %.2f", getPowerTotal());
+        // record the average poll time
+        avgPollTime.addNumber(pollEnd - pollStart);
+
+        // prevent overflow of the counters by halving them when reaching 10.000,
+        // which is sufficient for calculating the percentage of data
+        if (dataCounter == 10000) {
+            dataCounter /= 2;
+            identicalDataCounter /= 2;
+            errorCount /= 2;
+        }
+        dataCounter++;
+
+        // periodic information output
+        if (pollEnd - lastPrint > 30 * 1000) {
+            lastPrint = pollEnd;
+            DTU_LOGI("Average interval time: %ums, [Min: %u, Max: %u]",
+                avgIntervalTime.getAverage(), avgIntervalTime.getMin(), avgIntervalTime.getMax());
+            DTU_LOGI("Average poll time: %ums, [Min: %u, Max: %u]",
+                avgPollTime.getAverage(), avgPollTime.getMin(), avgPollTime.getMax());
+
+            if (dataCounter >= 10) {
+                DTU_LOGI("Http/Poll errors: %.1f%% [%u of %u polls]",
+                    (static_cast<float>(errorCount) / static_cast<float>(dataCounter)) * 100.0f,
+                    errorCount, dataCounter);
+                DTU_LOGI("Identical data: %.1f%% [%u of %u polls]",
+                    (static_cast<float>(identicalDataCounter) / static_cast<float>(dataCounter)) * 100.0f,
+                    identicalDataCounter, dataCounter);
+            }
+        }
     }
 }
 
@@ -192,7 +243,9 @@ Provider::poll_result_t Provider::poll()
 bool Provider::isDataValid() const
 {
     uint32_t age = millis() - getLastUpdate();
-    return getLastUpdate() > 0 && (age < (3 * _cfg.PollingInterval * 1000));
+
+    // consider data valid if last update was within 3 polling intervals, but at least 5 seconds
+    return getLastUpdate() > 0 && (age < std::max(5000u, 3 * _cfg.PollingIntervalMs));
 }
 
 } // namespace PowerMeters::Json::Http

--- a/webapp/src/types/PowerMeterConfig.ts
+++ b/webapp/src/types/PowerMeterConfig.ts
@@ -25,7 +25,7 @@ export interface PowerMeterHttpJsonValue {
 }
 
 export interface PowerMeterHttpJsonConfig {
-    polling_interval: number;
+    polling_interval_ms: number;
     individual_requests: boolean;
     values: Array<PowerMeterHttpJsonValue>;
 }

--- a/webapp/src/views/PowerMeterAdminView.vue
+++ b/webapp/src/views/PowerMeterAdminView.vue
@@ -157,10 +157,11 @@
 
                         <InputElement
                             :label="$t('powermeteradmin.pollingInterval')"
-                            v-model="powerMeterConfigList.http_json.polling_interval"
+                            v-model="httpJsonPollIntervalSeconds"
                             type="number"
-                            min="1"
+                            min="0.1"
                             max="15"
+                            step="0.1"
                             :postfix="$t('powermeteradmin.seconds')"
                             wide
                         />
@@ -369,6 +370,14 @@ export default defineComponent({
             },
             set(value: number) {
                 this.powerMeterConfigList.udp_victron.polling_interval_ms = value * 1000;
+            },
+        },
+        httpJsonPollIntervalSeconds: {
+            get(): number {
+                return this.powerMeterConfigList.http_json.polling_interval_ms / 1000;
+            },
+            set(value: number) {
+                this.powerMeterConfigList.http_json.polling_interval_ms = value * 1000;
             },
         },
     },


### PR DESCRIPTION
- HTTP/JSON: allow 500ms interval time
- HTTP/JSON: step size 100ms
- HTTP/JSON: log the poll time, errors and identical data
- HTTP/JSON: give more reconnection time
- HTTP/JSON: dataValid() min 5s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP JSON polling interval now supports decimal values (0.1s steps) from 0.1 to 15 seconds.

* **Improvements**
  * Polling interval is now stored/processed in milliseconds, with legacy configurations migrated automatically.
  * Values are clamped to 100–15000ms (0.1–15s) during configuration loading.
  * Guaranteed minimum connection timeout (2000ms) and smoother polling cadence to avoid overly-fast requests.
  * Enhanced polling timing/statistics, error reporting, and stricter data freshness validation (freshness must meet the updated threshold based on the interval, with a 5s minimum).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->