### PR TITLE
Feature: PowerMeter use request time for DataPoints

### DIFF
--- a/include/DataPoints.h
+++ b/include/DataPoints.h
@@ -78,14 +78,14 @@ class DataPointContainer {
         // be set, which means that this data point is "timeless" and hence is
         // ignored in the getLastUpdate() method.
         template<Label L>
-        void add(typename Traits<L>::type val, bool ignoreAge = false) {
+        void add(typename Traits<L>::type val, bool ignoreAge = false, uint32_t time = 0) {
             // no locking here! iff thread safety is required, use the lock()
             // method in a scoped block in which this method is called, as we
             // expect that usually multiple data points are added at a time.
 
             _dataPoints.erase(L);
 
-            uint32_t timestamp = ignoreAge ? 0 : millis();
+            uint32_t timestamp = (ignoreAge ? 0 : (time == 0 ? millis() : time));
             if (!ignoreAge && timestamp == 0) { timestamp = 1; }
 
             _dataPoints.emplace(

--- a/src/powermeter/json/http/Provider.cpp
+++ b/src/powermeter/json/http/Provider.cpp
@@ -162,6 +162,7 @@ void Provider::pollingLoop()
 Provider::poll_result_t Provider::poll()
 {
     JsonDocument jsonResponse;
+    auto pollStart = millis(); // used as timestamp for the data points
 
     auto prefixedError = [](uint8_t idx, char const* err) -> String {
         String res("Value ");
@@ -217,19 +218,21 @@ Provider::poll_result_t Provider::poll()
 
         if (cfg.SignInverted) { newValue *= -1; }
 
+        // Note: we use the poll start time as timestamp for the data point, because this is more safe
+        // and represents better the time when the measurement was taken
         {
             auto scopedLock = _dataCurrent.lock();
             switch (i) {
                 case 0:
-                    _dataCurrent.add<DataPointLabel::PowerL1>(newValue);
+                    _dataCurrent.add<DataPointLabel::PowerL1>(newValue, false, pollStart);
                     break;
 
                 case 1:
-                    _dataCurrent.add<DataPointLabel::PowerL2>(newValue);
+                    _dataCurrent.add<DataPointLabel::PowerL2>(newValue, false, pollStart);
                     break;
 
                 case 2:
-                    _dataCurrent.add<DataPointLabel::PowerL3>(newValue);
+                    _dataCurrent.add<DataPointLabel::PowerL3>(newValue, false, pollStart);
                     break;
 
                 default:


### PR DESCRIPTION
- optional time for DataPoints
- Use request time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Power measurements now preserve a more accurate timestamp when new data is collected, improving time-based views and history tracking.

* **Bug Fixes**
  * Fixed cases where newly received power data could be stored with an unintended timestamp.
  * Ensured data points continue to keep a valid timestamp when age tracking is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->